### PR TITLE
feat(cache): cache options array

### DIFF
--- a/etc/options.php
+++ b/etc/options.php
@@ -1,10 +1,10 @@
 <?php
 
 function orphang_indicator_options() {
-    $cached = wp_cache_get( 'orphang_indicator_options', 'iworks_orphans' );
-    if ($cached !== false) {
-        return $cached;
-    }
+	$cached = wp_cache_get( 'orphang_indicator_options', 'iworks_orphans' );
+	if ($cached !== false) {
+		return $cached;
+	}
 
 	$options = array();
 	/**

--- a/etc/options.php
+++ b/etc/options.php
@@ -1,6 +1,11 @@
 <?php
 
 function orphang_indicator_options() {
+    $cached = wp_cache_get( 'orphang_indicator_options', 'iworks_orphans' );
+    if ($cached !== false) {
+        return $cached;
+    }
+
 	$options = array();
 	/**
 	 * main settings
@@ -271,6 +276,8 @@ function orphang_indicator_options() {
 	);
 	$integrations = iworks_orphan_options_check_available_integrations();
 	if ( empty( $integrations ) ) {
+		wp_cache_set( 'orphang_indicator_options', $options, 'iworks_orphans' );
+
 		return $options;
 	}
 	$options['index']['options'][] = array(
@@ -310,6 +317,9 @@ function orphang_indicator_options() {
 			'classes'           => array( 'switch-button' ),
 		);
 	}
+
+	wp_cache_set( 'orphang_indicator_options', $options, 'iworks_orphans' );
+
 	return $options;
 }
 


### PR DESCRIPTION
the `orphang_indicator_options` function is called multiple times for both Admin Panel and normal page frontend. This causes the plugins to generate an array of options many times. As this array consists of post types, taxonomies and installed plugins it takes around 140ms of a load time of the webpage. With this cache this value is reduced to 1ms.

This is the load time reported by Code Profiler Pro before changes:
![image](https://github.com/iworks/sierotki/assets/828020/4f2ad9f9-09a6-4a74-aa4f-f6fae574bf8d)

This is the load time reported after the changes:
![image](https://github.com/iworks/sierotki/assets/828020/0d185bbf-82fb-4b9a-9f67-0cb2e7e5c238)

Probably what would be good here is to refresh the cache after new plugin is installed, new taxonomy or post type is created. Or we could add a button to flush it on the options page itself.